### PR TITLE
frontend(counselor): added more types to the table as  build was failing

### DIFF
--- a/frontend/src/app/manageCounselor/page.tsx
+++ b/frontend/src/app/manageCounselor/page.tsx
@@ -112,7 +112,7 @@ const ManageCounselor: React.FC = () => {
     {
       key: "Location",
       label: "LOCATION",
-      render: (row: Record<string, Record<string, unknown>>) => (
+      render: (row: CounselorRow) => (
         <>
           <div>
             <Image
@@ -173,7 +173,7 @@ const ManageCounselor: React.FC = () => {
   return (
     <div>
       <h1 className={styles.title}>Manage Members</h1>
-      <FilterableTable
+      <FilterableTable<CounselorRow>
         data={dummyData}
         columns={columns}
         filters={filters}

--- a/frontend/src/components/FilterableTable.tsx
+++ b/frontend/src/components/FilterableTable.tsx
@@ -7,25 +7,25 @@ import styles from "./FilterableTable.module.css";
 
 type RowData = Record<string, unknown>;
 
-type Column = {
+type Column<T = RowData> = {
   key: string;
   label: string;
-  render?: (row: RowData) => React.ReactNode;
+  render?: (row: T) => React.ReactNode;
 };
 
-type FilterableTableProps = {
-  data: RowData[];
-  columns: Column[];
+type FilterableTableProps<T = RowData> = {
+  data: T[];
+  columns: Column<T>[];
   filters: Record<string, string[]>;
   csvFilename?: string;
 };
 
-export const FilterableTable: React.FC<FilterableTableProps> = ({
+export const FilterableTable = <T extends RowData>({
   data,
   columns,
   filters,
   csvFilename = "data.csv",
-}) => {
+}: FilterableTableProps<T>) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [activeFilters, setActiveFilters] = useState<Record<string, string[]>>({});
   const [isFilterOpen, setIsFilterOpen] = useState(false);


### PR DESCRIPTION
## Tracking Info

Resolves #N/A

## CSS Checklist
- [x] Do you have width, padding, margin with a high (> ~ 100px) or negative value? Do you need it? Can  `rem `  `em `  `% `  `vw `  `vh` be used instead?
- [x] Did you avoid hard coding positions? (position, top, left, rules) Can  `display:flex; ` and justify and align uses be used instead?

## Changes

- Added More types to the manageCounselor and FilterTable parts as linter was not detecting it but it was failing on build

## Testing

- make sure frontend successfully builds
- ran frontend to ensure the table looks the same still

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->

TODO
